### PR TITLE
Fix TVX-351 - double iq result for mix-mam queries

### DIFF
--- a/src/java/org/jivesoftware/openfire/mix/MixManager.java
+++ b/src/java/org/jivesoftware/openfire/mix/MixManager.java
@@ -75,7 +75,7 @@ public class MixManager extends BasicModule {
 
 		MixChannelArchiveRepository mar = new JpaMixChannelArchiveRepositoryImpl("mam", this.getDbConfig());
 		QueryFactory queryFactory = new MamQueryFactory();
-		MessageArchiveService archive = new MessageArchiveServiceImpl(mar, router, queryFactory);
+		MessageArchiveService archive = new MessageArchiveServiceImpl(xmppServer, mar, router, queryFactory);
     	
     	this.persistenceManager = new MixPersistenceManagerImpl(JiveProperties.getInstance(), xmppService, 
     			new MixIdentityManager(CHANNEL_SEQ_TYPE, 5), new MixIdentityManager(MCP_SEQ_TYPE, 5), new MixIdentityManager(MCP_SUBS_SEQ_TYPE, 5), archive);

--- a/src/java/org/jivesoftware/openfire/mix/mam/MessageArchiveServiceImpl.java
+++ b/src/java/org/jivesoftware/openfire/mix/mam/MessageArchiveServiceImpl.java
@@ -26,13 +26,16 @@ import org.xmpp.packet.Message;
 public class MessageArchiveServiceImpl implements MessageArchiveService {
 	private static final Logger Log = LoggerFactory.getLogger(ArchivedMixChannelMessage.class);
 
+	private XMPPServer xmppServer;
+
 	private MixChannelArchiveRepository repository;
 
 	private PacketRouter router;
 
 	private QueryFactory queryFactory;
 
-	public MessageArchiveServiceImpl(MixChannelArchiveRepository mar, PacketRouter router, QueryFactory queryFactory) {
+	public MessageArchiveServiceImpl(XMPPServer xmppServer, MixChannelArchiveRepository mar, PacketRouter router, QueryFactory queryFactory) {
+		this.xmppServer = xmppServer;
 		this.repository = mar;
 		this.router = router;
 		this.queryFactory = queryFactory;
@@ -60,7 +63,7 @@ public class MessageArchiveServiceImpl implements MessageArchiveService {
 
 					ArchivedMixChannelMessage result = iter.next();
 
-					AccessControlDecisionFunction acdf = XMPPServer.getInstance().getAccessControlDecisionFunction();
+					AccessControlDecisionFunction acdf = xmppServer.getAccessControlDecisionFunction();
 					SecurityLabel outboundLabel = null;
 					if (acdf != null) {
 						SecurityLabel archiveLabel = result.getSecurityLabel();

--- a/src/java/org/jivesoftware/openfire/mix/mam/MessageArchiveServiceImpl.java
+++ b/src/java/org/jivesoftware/openfire/mix/mam/MessageArchiveServiceImpl.java
@@ -103,8 +103,6 @@ public class MessageArchiveServiceImpl implements MessageArchiveService {
 				set.addElement("last").addText(last);
 			}
 
-			router.route(response);
-
 		} else {
 			response = queryIQ.createCopy();
 			response.setType(Type.error);

--- a/src/test/java/org/jivesoftware/openfire/mix/mam/MessageArchiveServiceImplTest.java
+++ b/src/test/java/org/jivesoftware/openfire/mix/mam/MessageArchiveServiceImplTest.java
@@ -3,61 +3,80 @@ package org.jivesoftware.openfire.mix.mam;
 import static org.jivesoftware.openfire.mix.mam.repository.MamTestUtils.MIX_CHANNEL_JID;
 import static org.jivesoftware.openfire.mix.mam.repository.MamTestUtils.QUERY_ELEM_NAME;
 import static org.jivesoftware.openfire.mix.mam.repository.MamTestUtils.TEST_USERS_JID;
+import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import org.dom4j.DocumentFactory;
 import org.dom4j.Element;
 import org.jivesoftware.openfire.PacketRouter;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.mix.constants.ChannelJidVisibilityPreference;
 import org.jivesoftware.openfire.mix.mam.repository.MamTestUtils;
 import org.jivesoftware.openfire.mix.mam.repository.MixChannelArchiveRepository;
 import org.jivesoftware.openfire.mix.mam.repository.QueryFactory;
 import org.jivesoftware.openfire.mix.mam.repository.ResultSetQuery;
+import org.jivesoftware.openfire.mix.model.MessageBuilder;
+import org.jivesoftware.openfire.mix.model.MixChannelMessage;
+import org.jivesoftware.openfire.mix.model.MixChannelMessageImpl;
+import org.jivesoftware.openfire.mix.model.MixChannelParticipant;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.xmpp.packet.IQ;
 import org.xmpp.packet.Message;
+import org.xmpp.packet.Packet;
 
 public class MessageArchiveServiceImplTest {
+	Mockery context = new Mockery() {{
+		setImposteriser(ClassImposteriser.INSTANCE);
+	}};
 
 	private static final DocumentFactory docFactory = DocumentFactory.getInstance();
-
-	private Mockery context = new Mockery();
 
 	private MixChannelArchiveRepository mockRepository = context.mock(MixChannelArchiveRepository.class);
 
 	private PacketRouter mockRouter = context.mock(PacketRouter.class);
 
 	private QueryFactory mockFactory = context.mock(QueryFactory.class);
+
+	private XMPPServer mockXmppServer = context.mock(XMPPServer.class);
 	
-	private MessageArchiveService fixture = new MessageArchiveServiceImpl(mockRepository, mockRouter, mockFactory);
+	private MessageArchiveService fixture = new MessageArchiveServiceImpl(mockXmppServer, mockRepository, mockRouter, mockFactory);
 
 	private ResultSetQuery mockRSQuery = context.mock(ResultSetQuery.class);
 
 
 	@Test
-	@Ignore
 	public void testCorrectNumberOfMessagesSent() {
+		ArchivedMixChannelMessage archivedMessage = new ArchivedMixChannelMessage();
+		archivedMessage.setId("some-message-id");
+		archivedMessage.setStanza("<message />");
+		archivedMessage.setArchiveTimestamp(new Date());
 
 		final IQ filterQuery = this.getBaseQueryIQ();
 		context.checking(new Expectations() {{
 
 			final List<ArchivedMixChannelMessage> results = new ArrayList<>();
+			results.add(archivedMessage);
+
+			one(mockXmppServer).getAccessControlDecisionFunction();
+			will(returnValue(null));
 
 			one(mockFactory).create(mockRepository, filterQuery);
 			will(returnValue(mockRSQuery));
 			
 			one(mockRSQuery).execute();
 			will(returnValue(results));
-			
-			exactly(2).of(mockRouter).route(with(any(Message.class)));
-			one(mockRouter).route(with(any(IQ.class)));
+
+			one(mockRouter).route(with(any(Message.class)));
+			never(mockRouter).route(with(any(IQ.class)));
 		}});
 
-		fixture.query(filterQuery);
+		IQ result = fixture.query(filterQuery);
+		assertTrue(result.getType().equals(IQ.Type.result));
 
 		context.assertIsSatisfied();
 	}

--- a/src/test/java/org/jivesoftware/openfire/mix/mam/MessageArchiveServiceImplTest.java
+++ b/src/test/java/org/jivesoftware/openfire/mix/mam/MessageArchiveServiceImplTest.java
@@ -51,7 +51,7 @@ public class MessageArchiveServiceImplTest {
 
 	@Test
 	public void testCorrectNumberOfMessagesSent() {
-		ArchivedMixChannelMessage archivedMessage = new ArchivedMixChannelMessage();
+		final ArchivedMixChannelMessage archivedMessage = new ArchivedMixChannelMessage();
 		archivedMessage.setId("some-message-id");
 		archivedMessage.setStanza("<message />");
 		archivedMessage.setArchiveTimestamp(new Date());


### PR DESCRIPTION
We return the response to the caller, who routes it for us, no need to route the response ourselves.